### PR TITLE
Require manual start if AudioContext state is not running

### DIFF
--- a/src/paren/party.cljs
+++ b/src/paren/party.cljs
@@ -20,7 +20,7 @@
 (def manual-start?
   "Certain devices don't allow auto-playing sound, so we have to introduce a
   manual start so the music plays."
-  (or MOBILE WINDOWS))
+  (or MOBILE WINDOWS (not= (.-state (new js/AudioContext)) "running")))
 
 
 (defonce started? (atom false))


### PR DESCRIPTION
According to https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio,
if AudioContext state is not "running", user's interaction is required to play web audio